### PR TITLE
Upgrade ruby27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs: # a collection of steps
   build-test:
     parallelism: 1
     docker: # run the steps with Docker
-      - image: cimg/ruby:2.5.8-node # ...with this image as the primary container; this is where all `steps` will run
+      - image: cimg/ruby:2.7.8-node # ...with this image as the primary container; this is where all `steps` will run
         environment: # environment variables for primary container
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage/
 tmp/
 *.log
+/deprecations/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rails
+require:
+  - rubocop-rails
+  - ./rubocop/cop/lint/last_keyword_argument
 
 AllCops:
   NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'deprecation_toolkit', '~> 2', require: false
   gem 'factory_bot_rails', '~> 5'
   gem 'pry', '~> 0'
   gem 'pry-remote', '~> 0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ def next?
 end
 source 'https://rubygems.org'
 
-ruby '2.5.8'
+ruby '2.7.8'
 gem 'rails', '5.2.8.1'
 
 gem 'pg', '~> 0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    deprecation_toolkit (2.0.3)
+      activesupport (>= 5.2)
     devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -304,6 +306,7 @@ PLATFORMS
 DEPENDENCIES
   annotate (~> 2.7.4)
   bootstrap-sass (~> 3.3.4)
+  deprecation_toolkit (~> 2)
   devise (= 4.6.2)
   factory_bot_rails (~> 5)
   hideable (= 0.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,7 +334,7 @@ DEPENDENCIES
   will_paginate (>= 3.1.7, < 4)
 
 RUBY VERSION
-   ruby 2.5.8p224
+   ruby 2.7.8p225
 
 BUNDLED WITH
-   2.2.0
+   2.4.10

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -15,7 +15,7 @@
     <br />
     <p>
     (I’m no scientist; here’s an article by Harvard Medical School saying these things with references:
-        <a href="http://www.health.harvard.edu/newsletter_article/in-praise-of-gratitude">In Praise of Gratitude</a>)
+        <a href="https://www.health.harvard.edu/blog/in-praise-of-gratitude-201211215561">In Praise of Gratitude</a>)
     </p>
     <br />
     <p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,13 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :file delivery method writes to tmp/mails
+  # See: https://github.com/rails/rails/blob/8030cff808657faa44828de001cd3b80364597de/actionmailer/lib/action_mailer/delivery_methods.rb#L29
+  config.action_mailer.delivery_method = :file
+  config.action_mailer.default_url_options = { :host => 'localhost:5000' }
+  Rails.application.routes.default_url_options[:host] = 'localhost:5000'
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   # The :file delivery method writes to tmp/mails
   # See: https://github.com/rails/rails/blob/8030cff808657faa44828de001cd3b80364597de/actionmailer/lib/action_mailer/delivery_methods.rb#L29
   config.action_mailer.delivery_method = :file
-  config.action_mailer.default_url_options = { :host => 'localhost:5000' }
+  config.action_mailer.default_url_options = { host: 'localhost:5000' }
   Rails.application.routes.default_url_options[:host] = 'localhost:5000'
 
   # Don't care if the mailer can't send.

--- a/rubocop/cop/lint/last_keyword_argument.rb
+++ b/rubocop/cop/lint/last_keyword_argument.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # This cop only works if there are files from deprecation_toolkit. You can
+      # generate these files by:
+      #
+      # 1. Running specs with RECORD_DEPRECATIONS=1
+      # 1. Downloading the complete set of deprecations/ files from a CI
+      # pipeline (see https://gitlab.com/gitlab-org/gitlab/-/merge_requests/47720)
+      class LastKeywordArgument < RuboCop::Cop::Base
+        extend RuboCop::Cop::AutoCorrector
+
+        MSG = 'Using the last argument as keyword parameters is deprecated'
+
+        DEPRECATIONS_GLOB = File.expand_path('../../../deprecations/**/*.yml', __dir__)
+        KEYWORD_DEPRECATION_STR = 'maybe ** should be added to the call'
+
+        def on_send(node)
+          return if target_ruby_version >= 3.0
+
+          arg = get_last_argument(node)
+          return unless arg
+
+          return unless known_match?(processed_source.file_path, node.first_line, node.method_name.to_s)
+
+          return if arg.children.first.respond_to?(:kwsplat_type?) && arg.children.first&.kwsplat_type?
+
+          # parser thinks `a: :b, c: :d` is hash type, it's actually kwargs
+          return if arg.hash_type? && !arg.source.match(/\A{/)
+
+          add_offense(arg) do |corrector|
+            if arg.hash_type?
+              kwarg = arg.source.sub(/\A{\s*/, '').sub(/\s*}\z/, '')
+              corrector.replace(arg, kwarg)
+            elsif arg.splat_type?
+              corrector.insert_before(arg, '*')
+            else
+              corrector.insert_before(arg, '**')
+            end
+          end
+        end
+
+        private
+
+        def get_last_argument(node)
+          return node.arguments[-2] if node.block_argument?
+
+          node.arguments.last
+        end
+
+        def known_match?(file_path, line_number, method_name)
+          method_name = 'initialize' if method_name == 'new'
+
+          return unless self.class.keyword_warnings[method_name]
+
+          file_path_from_root = file_path.sub(File.expand_path('../../..', __dir__), '')
+          file_and_line = "#{file_path_from_root}:#{line_number}"
+
+          self.class.keyword_warnings[method_name].any? do |warning|
+            warning.include?(file_and_line)
+          end
+        end
+
+        def self.keyword_warnings
+          @keyword_warnings ||= keywords_list
+        end
+
+        def self.keywords_list
+          hash = Dir.glob(DEPRECATIONS_GLOB).each_with_object({}) do |file, hash|
+            hash.merge!(YAML.safe_load(File.read(file)))
+          end
+
+          hash.values.flatten.each_with_object({}) do |str, results|
+            next unless str.include?(KEYWORD_DEPRECATION_STR)
+
+            match_data = str.match(/called method `([^\s]+)'/)
+            next unless match_data
+
+            key = match_data[1]
+            results[key] ||= []
+            results[key] << str
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/deprecation_toolkit_env.rb
+++ b/test/deprecation_toolkit_env.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if ENV.key?('RECORD_DEPRECATIONS')
+  require 'deprecation_toolkit'
+  DeprecationToolkit::Configuration.deprecation_path = 'deprecations'
+  DeprecationToolkit::Configuration.behavior = DeprecationToolkit::Behaviors::Record
+
+  # Enable ruby deprecations for keywords, it's suppressed by default in Ruby 2.7.2
+  Warning[:deprecated] = true
+
+  kwargs_warnings = [
+    # Taken from https://github.com/jeremyevans/ruby-warning/blob/1.3.0/lib/warning.rb#L18
+    # rubocop:disable Layout/LineLength
+    /: warning: (?:Using the last argument (?:for `.+' )?as keyword parameters is deprecated; maybe \*\* should be added to the call|Passing the keyword argument (?:for `.+' )?as the last hash parameter is deprecated|Splitting the last argument (?:for `.+' )?into positional and keyword parameters is deprecated|The called method (?:`.+' )?is defined here)\n\z/
+    # rubocop:enable Layout/LineLength
+  ]
+  DeprecationToolkit::Configuration.warnings_treated_as_deprecation = kwargs_warnings
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 require 'simplecov-lcov'
+require './test/deprecation_toolkit_env'
 
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 FORMATTERS = [


### PR DESCRIPTION
In addition to upgrading to latest Ruby 2.7.x
I add a custom cop and workflow to handle Ruby 2.7 deprecations.

The cop is marked unsafe, to autocorrect you need to use -A

Usage:

    RECORD_DEPRECATIONS=1 bundle exec rake test # generates files under deprecations/
    bundle exec rubocop --only Lint/LastKeywordArgument

See: https://about.gitlab.com/blog/2021/02/03/how-we-automatically-fixed-hundreds-of-ruby-2-7-deprecation-warnings/
